### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,10 @@
     "autoload": {
         "psr-0": { "HappyR\\Google\\ApiBundle": "" }
     },
-    "target-dir": "HappyR/Google/ApiBundle"
-    
+    "target-dir": "HappyR/Google/ApiBundle",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1.x-dev"
+        }
+    }    
 }


### PR DESCRIPTION
Allow users to put "2.1.0@dev" in their composer.json instead of "dev-master" (dev-master is bad)
