### PR TITLE
Update bundle to add support of Google API 2.0

### DIFF
--- a/Services/GoogleClient.php
+++ b/Services/GoogleClient.php
@@ -27,7 +27,13 @@ class GoogleClient
 
         $client = new \Google_Client($config);
         if ($symfonyLogger) {
-            $client->setLogger($symfonyLogger);
+            //BC for Google API 1.0
+            if (class_exists('\Google_Logger_Psr')) {
+                $googleLogger = new \Google_Logger_Psr($client, $symfonyLogger);
+                $client->setLogger($googleLogger);
+            } else {
+                $client->setLogger($symfonyLogger);
+            }
         }
 
         $client -> setApplicationName($config['application_name']);

--- a/Services/GoogleClient.php
+++ b/Services/GoogleClient.php
@@ -27,8 +27,7 @@ class GoogleClient
 
         $client = new \Google_Client($config);
         if ($symfonyLogger) {
-            $googleLogger = new \Google_Logger_Psr($client, $symfonyLogger);
-            $client->setLogger($googleLogger);
+            $client->setLogger($symfonyLogger);
         }
 
         $client -> setApplicationName($config['application_name']);

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,7 +1,7 @@
 UPGRADING
 =========
 
-Upgrade from version 2.\* to 3.\*
+Upgrade from version 2.1.\* to 2.2.\*
 -------------------------------
-* Since version 3.\*, we support version 2.\* of the Google API. Although this doesn't change much to the API of this bundle, you should be aware that many things changed (including authentication) in the Google API. See https://github.com/google/google-api-php-client/blob/master/UPGRADING.md.
+* Since version 2.2.\*, we support version 2.\* of the Google API. Although this doesn't change much to the API of this bundle, you should be aware that many things changed (including authentication) in the Google API. See https://github.com/google/google-api-php-client/blob/master/UPGRADING.md.
 If you do not want to upgrade, you should add the version constraint `"google/apiclient": "1.*"` to your `composer.json`.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,6 @@
+UPGRADING
+=========
+
+Upgrade from version 2.\* to 3.\*
+-------------------------------
+* Since version 3.\*, we use version 2.\* of the Google API. Although this doesn't change much to the API of this bundle, you should be aware that many things changed (including authentication) in the Google API. See https://github.com/google/google-api-php-client/blob/master/UPGRADING.md.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,4 +3,5 @@ UPGRADING
 
 Upgrade from version 2.\* to 3.\*
 -------------------------------
-* Since version 3.\*, we use version 2.\* of the Google API. Although this doesn't change much to the API of this bundle, you should be aware that many things changed (including authentication) in the Google API. See https://github.com/google/google-api-php-client/blob/master/UPGRADING.md.
+* Since version 3.\*, we support version 2.\* of the Google API. Although this doesn't change much to the API of this bundle, you should be aware that many things changed (including authentication) in the Google API. See https://github.com/google/google-api-php-client/blob/master/UPGRADING.md.
+If you do not want to upgrade, you should add the version constraint `"google/apiclient": "1.*"` to your `composer.json`.

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=5.3.2",
         "symfony/framework-bundle": "2.*|~3.0",
         "symfony/yaml": "2.*|~3.0",
-        "google/apiclient": "2.*"
+        "google/apiclient": "1.*|2.*"
     },
     "require-dev": {
         "mockery/mockery": "*"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=5.3.2",
         "symfony/framework-bundle": "2.*|~3.0",
         "symfony/yaml": "2.*|~3.0",
-        "google/apiclient": "1.*"
+        "google/apiclient": "2.*"
     },
     "require-dev": {
         "mockery/mockery": "*"
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.2.x-dev"
+            "dev-master": "3.0.x-dev"
         }
     }    
 }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0.x-dev"
+            "dev-master": "2.3.x-dev"
         }
     }    
 }


### PR DESCRIPTION
Adds support for the Google PHP API v2.0.
As this is quite a large change (not in the bundle but for the Google API), I propose to bump the version as well.