### PR TITLE
Config key to use Google Account Service

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -34,6 +34,7 @@ class Configuration implements ConfigurationInterface
             ->scalarNode('cacheClass')->end()
             ->scalarNode('basePath')->end()
             ->scalarNode('ioFileCache_directory')->end()
+            ->scalarNode('auth_config_file_path')->defaultNull()->end()
           //end rootnode children
           ->end();
 

--- a/Services/GoogleClient.php
+++ b/Services/GoogleClient.php
@@ -42,6 +42,10 @@ class GoogleClient
         $client -> setRedirectUri($config['oauth2_redirect_uri']);
         $client -> setDeveloperKey($config['developer_key']);
 
+        if (! empty($config['auth_config_file_path'])) {
+            $client->setAuthConfig($config['auth_config_file_path']);
+        }
+
         $this -> client = $client;
     }
 

--- a/Tests/Services/GoogleClientTest.php
+++ b/Tests/Services/GoogleClientTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Services;
+
+use HappyR\Google\ApiBundle\Services\GoogleClient;
+use PHPUnit\Framework\TestCase;
+
+class GoogleClientTest extends TestCase
+{
+    public function testInConstructorIfAuthConfigFilePathIsEmptyTheAssociatedMethodMustNotBeCalled()
+    {
+        $config = [
+            'auth_config_file_path' => null,
+            'application_name' => null,
+            'oauth2_client_id' => null,
+            'oauth2_client_secret' => null,
+            'oauth2_redirect_uri' => null,
+            'developer_key' => null,
+        ];
+
+        new GoogleClient($config);
+
+        $this->assertTrue(true);
+    }
+
+    public function testInConstructorIfAuthConfigFilePathIsFillTheAssociatedMethodMustThrowNotExistingFileMethod()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+        $config = [
+            'auth_config_file_path' => 'foofile.json',
+            'application_name' => null,
+            'oauth2_client_id' => null,
+            'oauth2_client_secret' => null,
+            'oauth2_redirect_uri' => null,
+            'developer_key' => null,
+        ];
+
+        new GoogleClient($config);
+
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
This PR introduces the possibility to use Google Account Service with bundle.
https://developers.google.com/identity/protocols/OAuth2ServiceAccount